### PR TITLE
Make the getHeaders() method public

### DIFF
--- a/src/API.php
+++ b/src/API.php
@@ -654,7 +654,7 @@ class API
      *
      * @return array  contains headers to use for HTTP requests
      */
-    private function getHeaders($method)
+    public function getHeaders($method)
     {
         $headers = array();
 


### PR DESCRIPTION
The PHP API currently contains no classes for the OAuth authorzation dance.

So, the developer (me!) has to write their own code for that.

In doing so, he doesn't want to re-invent the wheel, by re-creating getHeaders(). Hence, I propose making it public.