### PR TITLE
Revert "make wakeup() private"

### DIFF
--- a/src/API.php
+++ b/src/API.php
@@ -53,7 +53,7 @@ class API
      * Wakeup function on unserialize
      * 
      */
-    private function __wakeup()
+    public function __wakeup()
     {
         // curl setup
         $this->curl = curl_init();


### PR DESCRIPTION
This reverts commit 7758a0e5bd371bab2162ac68c8c4eefa5262370b.

`__wakeup()` must be public.